### PR TITLE
Fix core2forAWS.h includes

### DIFF
--- a/main/clock.c
+++ b/main/clock.c
@@ -33,7 +33,7 @@
 #include "freertos/semphr.h"
 #include "esp_log.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 #include "clock.h"
 
 static const char *TAG = CLOCK_TAB_NAME;

--- a/main/crypto.c
+++ b/main/crypto.c
@@ -33,7 +33,7 @@
 
 #include "esp_log.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 
 #include "crypto.h"
 

--- a/main/cta.c
+++ b/main/cta.c
@@ -31,7 +31,7 @@
 
 #include "esp_log.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 
 #include "cta.h"
 

--- a/main/home.c
+++ b/main/home.c
@@ -32,7 +32,7 @@
 
 #include "esp_log.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 
 #include "home.h"
 

--- a/main/led_bar.c
+++ b/main/led_bar.c
@@ -32,7 +32,7 @@
 
 #include "esp_log.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 #include "led_bar.h"
 
 #define RED_AMAZON_ORANGE 255

--- a/main/main.c
+++ b/main/main.c
@@ -45,7 +45,7 @@
 #include "esp_event.h"
 #include "nvs_flash.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 
 #include "sound.h"
 #include "home.h"

--- a/main/mic.c
+++ b/main/mic.c
@@ -33,7 +33,7 @@
 
 #include "driver/i2s.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 
 #include "mic.h"
 #include "fft.h"

--- a/main/mpu.c
+++ b/main/mpu.c
@@ -34,7 +34,7 @@
 
 #include "esp_log.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 
 #include "mpu.h"
 

--- a/main/power.c
+++ b/main/power.c
@@ -32,7 +32,7 @@
 
 #include "esp_log.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 
 #include "power.h"
 

--- a/main/sound.c
+++ b/main/sound.c
@@ -29,7 +29,7 @@
 #include "freertos/task.h"
 #include "freertos/semphr.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 
 #include "sound.h"
 

--- a/main/touch.c
+++ b/main/touch.c
@@ -33,7 +33,7 @@
 
 #include "esp_log.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 
 #include "touch.h"
 

--- a/main/wifi.c
+++ b/main/wifi.c
@@ -35,7 +35,7 @@
 #include "esp_log.h"
 #include "esp_event.h"
 
-#include "core2forAWS.h"
+#include "core2foraws.h"
 
 #include "wifi.h"
 


### PR DESCRIPTION
The project was failing to compile due to not being able to find a header by the name of "core2forAWS.h". Changing the references to the BSP's new capitalization of "core2foraws.h" fixed the errors and allowed the project to compile.

Compiles successfully and runs on device properly.